### PR TITLE
Exclude external js from minification

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <dev>
+            <js>
+                <minify_exclude>
+                    <onilab_googlechart_fix>\.gstatic.com/charts/</onilab_googlechart_fix>
+                </minify_exclude>
+            </js>
+        </dev>
+    </default>
+</config>


### PR DESCRIPTION
Exclude https://www.gstatic.com/charts/loader.js from minification, which causes https://github.com/onilab/magento-2-google-api-chart-fix/issues/1